### PR TITLE
lm - [TASK] Reintroduce React ESLint Rules (#7)

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -3,6 +3,7 @@ import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import { defineConfig, globalIgnores } from "eslint/config";
+import reactPlugin from "eslint-plugin-react";
 
 // Import the vitest plugin
 import vitest from "@vitest/eslint-plugin";
@@ -25,6 +26,7 @@ export default defineConfig([
       js.configs.recommended,
       reactHooks.configs["recommended-latest"],
       reactRefresh.configs.vite,
+      reactPlugin.configs.flat.recommended,
     ],
     languageOptions: {
       ecmaVersion: 2020,
@@ -40,6 +42,8 @@ export default defineConfig([
         "error",
         { varsIgnorePattern: "^[A-Z_].*", argsIgnorePattern: "^_" },
       ],
+      "react/prop-types": "off",
+      "react/react-in-jsx-scope": "off",
     },
   },
   {

--- a/frontend/src/main/components/Commons/CommonsList.jsx
+++ b/frontend/src/main/components/Commons/CommonsList.jsx
@@ -58,7 +58,7 @@ const CommonsList = (props) => {
                     { fontFamily: "Sancreek", paddingBottom: "10px" }
                   }
                 >
-                  Common's Name
+                  Common&apos;s Name
                 </Col>
                 <Col sm={4}></Col>
               </Row>

--- a/frontend/src/main/components/Commons/ManageCowsModal.jsx
+++ b/frontend/src/main/components/Commons/ManageCowsModal.jsx
@@ -75,7 +75,7 @@ const ManageCowsModal = ({
           </Form.Group>
           <Form.Group>
             <Form.Label>
-              Please specify the number of cows you'd like to {message} below.
+              Please specify the number of cows you&apos;d like to {message} below.
             </Form.Label>
           </Form.Group>
           <Form.Group>

--- a/frontend/src/main/components/Jobs/UpdateCowHealthForm.jsx
+++ b/frontend/src/main/components/Jobs/UpdateCowHealthForm.jsx
@@ -41,7 +41,7 @@ function UpdateCowHealthForm({ submitAction, testid = "UpdateCowHealthForm" }) {
     <Form onSubmit={handleSubmit(onSubmit)}>
       <Form.Group className="mb-3">
         <Form.Text htmlFor="description">
-          Updated the cows' health in a single or all commons.
+          Updated the cows&apos; health in a single or all commons.
         </Form.Text>
       </Form.Group>
 

--- a/frontend/src/main/components/OurTable.jsx
+++ b/frontend/src/main/components/OurTable.jsx
@@ -43,9 +43,10 @@ export default function OurTable({
       <Table style={tableStyle} {...getTableProps()} striped bordered hover>
         <thead>
           {headerGroups.map((headerGroup) => (
-            <tr {...headerGroup.getHeaderGroupProps()}>
+            <tr key={headerGroup.id} {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map((column) => (
-                <th
+                <th 
+                  key={column.id}
                   {...column.getHeaderProps(column.getSortByToggleProps())}
                   data-testid={`${testid}-header-${column.id}`}
                 >
@@ -70,10 +71,11 @@ export default function OurTable({
             .map((row) => {
               prepareRow(row);
               return (
-                <tr {...row.getRowProps()}>
+                <tr key={row.id} {...row.getRowProps()}>
                   {row.cells.map((cell, _index) => {
                     return (
                       <td
+                        key={cell.column.id}
                         {...cell.getCellProps()}
                         data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                       >

--- a/frontend/src/main/pages/AdminViewPlayPage.jsx
+++ b/frontend/src/main/pages/AdminViewPlayPage.jsx
@@ -99,7 +99,7 @@ const AdminViewPlayPage = () => {
             <Card.Title>
               This is a Admin Feature for <strong>{admin_name}</strong>
               <br />
-              Visiting Farmer <strong>{visiting_user}</strong>'s Play Page for
+              Visiting Farmer <strong>{visiting_user}</strong>&apos;s Play Page for
               common <strong>{visiting_commons}</strong> in Read Only Mode.
             </Card.Title>
           </Card.Body>

--- a/frontend/src/main/pages/LeaderboardPage.jsx
+++ b/frontend/src/main/pages/LeaderboardPage.jsx
@@ -85,7 +85,7 @@ export default function LeaderboardPage() {
               />
             </>
           ) : (
-            <p>You're not authorized to see the leaderboard.</p>
+            <p>You&apos;re not authorized to see the leaderboard.</p>
           )}
         </div>
       </BasicLayout>


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we restore the React ESlint Rules that were removed when migrating from create-react-app to Vite. After adding the rules back in the `eslint.config.mjs` file introduced lint errors, that are all resolved in this PR.

## Validation
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch
2. Run `npm install` using node -v 22.18.0 
3. Run `npm runt lint` and ensure no errors are thrown
4. Run `npm test` and all tests should pass
5. Run `npm run dev` and the frontend should launch with no errors

## Tests
<!--Add any additional tests or required tests-->
- [ ] Frontend Linting (`npm run dev`) pass
- [ ] Frontend Unit tests (`npm test`) pass

## Linked Issues
<!--Issues related to the PR-->
Closes #7 
