### PR TITLE
FV - Add CommonsFeatures enum to backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/enums/CommonsFeatures.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/enums/CommonsFeatures.java
@@ -1,0 +1,5 @@
+package edu.ucsb.cs156.happiercows.enums;
+
+public enum CommonsFeatures {
+    FARMERS_CAN_SEE_LEADERBOARD
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/enums/CommonsFeaturesTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/enums/CommonsFeaturesTests.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.happiercows.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommonsFeaturesTests {
+
+  @Test
+  void testEnumLoads() {
+    assertNotNull(CommonsFeatures.FARMERS_CAN_SEE_LEADERBOARD);
+  }
+}


### PR DESCRIPTION
# Summary
This PR introduces a new enum `CommonsFeatures` in the backend to support a generalized feature-flag system for commons.

## What was added
- New file: `CommonsFeatures.java` in `edu.ucsb.cs156.happiercows.enums`
- First enum value: `FARMERS_CAN_SEE_LEADERBOARD`

## Purpose
This is the first step in a larger refactor to support enabling/disabling commons features through a database-backed feature toggle system. Future steps will involve:
- Adding more enum values
- Creating a backend table for feature flags
- Adding API endpoints for admins to update feature configuration
- Building a frontend component to manage features

## Verification
- Project builds successfully
- Class compiles cleanly with no references or dependencies required

Closes #25 